### PR TITLE
fix: stable and auto-synchronized frame reads

### DIFF
--- a/p3_camera_test.py
+++ b/p3_camera_test.py
@@ -20,7 +20,6 @@ from p3_camera import (
     SYNC_START_ODD,
     TEMP_SCALE,
     EnvParams,
-    FrameIncompleteError,
     FrameMarkerMismatchError,
     FrameStats,
     GainMode,
@@ -455,10 +454,6 @@ class TestDataClasses:
 
 class TestExceptions:
     """Tests for custom exceptions."""
-
-    def test_frame_incomplete_error(self):
-        with pytest.raises(FrameIncompleteError):
-            raise FrameIncompleteError("Test error")
 
     def test_frame_marker_mismatch_error(self):
         """Test FrameMarkerMismatchError exception."""

--- a/p3_viewer.py
+++ b/p3_viewer.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from enum import IntEnum
 from typing import Any, cast
 
+import logging
 import time
 
 from numpy.typing import NDArray
@@ -630,6 +631,8 @@ def main() -> None:
         help="Camera model (default: p3)",
     )
     args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG)
 
     try:
         P3Viewer(model=args.model).run()


### PR DESCRIPTION
Hello, with older code, we were getting the de-sync, as described in #5. With code from Jan 19, we're seeing #6 
- On Mac, the error says "overflow"
- On Windows, it says "the device is not working", and is not recoverable (catching the error is not enough, just happens again)
- It appears to be related to timing - sometimes on Windows, it starts up right, but when you try to move the window (which blocks OpenCV loop I guess?) it breaks every time

However, with older code with the 16kb reads, the USB never stopped working, even when moving the window - we were just getting the de-sync of frame data.

This PR reverts to the old method of 16KB reads, but auto-synchronizes on the end frame marker read, which is always 12 bytes and allows us to find out if we missed something or not.

Tested on Mac, Windows and Linux with P3, works perfectly - no crashes and no corrupted frames (just some skipped when moving viewer window and on startup). Unfortunately I don't have P1 to test, so I don't know if it does the same 12-byte read or not.

Interestingly, on Linux, it works well both with and without this fix. I guess the USB driver is better there...

Fixes #6